### PR TITLE
Reduce frequency of Dependabot to run weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,10 +6,10 @@ updates:
     labels:
       - dependabot
     schedule:
-      interval: daily
+      interval: weekly
   - package-ecosystem: docker
     directory: "/"
     labels:
       - dependabot
     schedule:
-      interval: daily
+      interval: weekly


### PR DESCRIPTION
Having daily updates is too much, weekly will be ok.