### PR TITLE
Add GitHub workflow to check Golang vulnerabilities using Snyk

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -1,0 +1,22 @@
+name: Check Golang vulnerabilities using Snyk
+# https://docs.snyk.io/integrations/snyk-ci-cd-integrations/github-actions-integration/snyk-golang-action
+
+on: push
+jobs:
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+
+      - name: Run Snyk to check for vulnerabilities
+        uses: snyk/actions/golang@master
+        continue-on-error: true # To make sure that SARIF upload gets called
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          args: --sarif-file-output=snyk.sarif
+
+      - name: Upload result to GitHub Code Scanning
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: snyk.sarif


### PR DESCRIPTION
Description/Why:
We want to test GitHub Code Scanning and Snyk, so let's begin by uploading Snyk scan results to GitHub Code Scanning.