### PR TITLE
fix(build): upgrade Go to 1.26.2 to fix stdlib crypto vulnerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26 as builder
+FROM golang:1.26.2 as builder
 
 ENV CGO_ENABLED=0
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/AirHelp/autoscaler
 
-go 1.25.0
+go 1.26.2
 
 require (
 	github.com/alicebob/miniredis/v2 v2.35.0


### PR DESCRIPTION
## Description/Why

Snyk reported 4 vulnerabilities in Go stdlib shipped with Go 1.26.1:

- SNYK-GOLANG-STDCRYPTOTLS-15928849 — High: TLS resource exhaustion (fixed in 1.26.2)
- SNYK-GOLANG-STDCRYPTOX509-15928850 — High: improper certificate name case handling (fixed in 1.26.2)
- SNYK-GOLANG-STDCRYPTOX509-15928851 — Medium: x509 resource allocation (fixed in 1.26.2)
- SNYK-GOLANG-STDCRYPTOX509-15928852 — Medium: x509 resource allocation (fixed in 1.26.2)

## Changes

- `Dockerfile`: pin base image to `golang:1.26.2`
- `go.mod`: update `go` directive to `1.26.2`

All 9 tests pass.

---

**Note on Snyk CI failure**

The Snyk check fails because their CI environment runs Go 1.26.1 with `GOTOOLCHAIN=local` and cannot process a `go.mod` requiring `go >= 1.26.2`. This is a limitation on Snyk's side — their infrastructure needs to be updated to Go 1.26.2.

The vulnerability fix itself is correct: the Dockerfile now pins `golang:1.26.2`, which builds with the patched stdlib. The `go.mod` directive is intentionally set to `1.26.2` to reflect the actual minimum required toolchain.