### PR TITLE
chore: upgrade actions/checkout to v6.0.2 (node24)

### DIFF
--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -10,7 +10,7 @@ jobs:
     env:
       CGO_ENABLED: 0
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
       CGO_ENABLED: 0
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -6,7 +6,7 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Run Snyk to check for vulnerabilities
         uses: snyk/actions/golang@master


### PR DESCRIPTION
Upgrades `actions/checkout` to v6.0.2 across all workflows.

GitHub Actions will drop support for Node.js versions below 24 on April 30, 2026
(Node 20 EOL) and runners will switch to Node 24 by default on June 2, 2026.

All checkout calls replaced with SHA-pinned v6.0.2 (node24):
`de0fac2e4500dabe0009e67214ff5f5447ce83dd`