### PR TITLE
chore: upgrade actions to node24 versions

### DIFF
--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -11,7 +11,7 @@ jobs:
       CGO_ENABLED: 0
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: 'go.mod'
       - run: go mod download

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,10 +20,10 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: 'Login to GitHub Container Registry'
-        uses: docker/login-action@v3
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{github.actor}}
@@ -31,7 +31,7 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -41,7 +41,7 @@ jobs:
 
       - name: Build image and push to GitHub Container Registry
         id: docker_build
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -8,7 +8,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/stale@v4
+    - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0
       with:
         days-before-issue-stale: 30
         days-before-pr-stale: 14


### PR DESCRIPTION
## Overview

  Upgrade GitHub Actions to versions compatible with Node.js 24, which becomes the default runtime in June 2026.

  ## Changes

  - `actions/setup-go`: v5 → v6.4.0
  - `actions/stale`: v4 → v10.2.0
  - `docker/setup-buildx-action`: v3 → v4.0.0
  - `docker/login-action`: v3 → v4.1.0
  - `docker/metadata-action`: v5 → v6.0.0
  - `docker/build-push-action`: v5 → v7.1.0

  All external actions are pinned to commit SHAs for supply-chain security.
No workflow logic changes — upgrade only
  ## Breaking Changes Assessment

  All major version upgrades were reviewed for compatibility:

  ### actions/stale (v4→v10)
  - **v7**: Exempt labels no longer auto-managed — not applicable here
  - **v9**: Now stateful, resuming from first unprocessed item on limits — safe behavioral change
  - **v10**: Node.js 24 runtime — compatible

  ### docker/build-push-action (v5→v7)
  - Removed deprecated env vars (`DOCKER_BUILD_NO_SUMMARY`, `DOCKER_BUILD_EXPORT_RETENTION_DAYS`) — not used
  - Legacy export-build tool removed — not used
  - ESM module system — transparent upgrade

  ### actions/setup-go (v5→v6)
  - Improved toolchain handling — compatible with `go-version-file: 'go.mod'`
  - Node.js 24 runtime — compatible

  **Conclusion**: All breaking changes either don't / should not affect the workflows. 

